### PR TITLE
docs: stylize README notes the GitHub way

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ To run the graphical version, start with:
 $ python3 pytris --pygame
 ```
 
-> **Note** <br>
+> [!NOTE]
 > The GUI version may open when you use `python3 pytris`. If this happens, use `python3 pytris --terminal` instead.
 
-> **Note** <br>
+> [!NOTE]
 > Windows users may need to use `py` instead of `python3`.
 
 ### Multiplayer
@@ -40,5 +40,5 @@ Within the terminal, or double click it using your file manager (e.g. File Explo
 
 Alternatively, manually create a shell script, shortcut, or desktop file to start it with any arguments you want (or edit the generated files).
 
-> **Note** <br>
+> [!NOTE]
 > If you use a method to start pytris which doesn't give it a terminal, e.g. a shortcut using `pythonw.exe` on Windows or a desktop file with `Terminal=false`, the GUI version will attempt to run unless otherwise specified using `--terminal`.


### PR DESCRIPTION
I recently learnt that GitHub has its own way of making 'notes' in markdown documents styled, similarly to Forgejo.

However, unlike Forgejo, these notes will appear as `[!NOTE]` when viewed in plaintext, and also with [glow](https://github.com/charmbracelet/glow); I'm unsure about other markdown readers.

Formatting of notes being non-universal, consider this PR to be a double-edged blade.